### PR TITLE
ST-5 Noti 수가 맞는 걸 확인

### DIFF
--- a/src/main/java/net/slipp/todo_list/AppConfig.java
+++ b/src/main/java/net/slipp/todo_list/AppConfig.java
@@ -1,10 +1,17 @@
 package net.slipp.todo_list;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 
 @Configuration
 @ComponentScan(basePackages = {"net.slipp.todo_list"})
 public class AppConfig {
+  @Bean
+  @Primary
+  public CountableNotiManager countableNotiManager() {
+    return new CountableNotiManager();
+  }
 }

--- a/src/main/java/net/slipp/todo_list/AppConfig.java
+++ b/src/main/java/net/slipp/todo_list/AppConfig.java
@@ -10,8 +10,7 @@ import org.springframework.context.annotation.Primary;
 @ComponentScan(basePackages = {"net.slipp.todo_list"})
 public class AppConfig {
   @Bean
-  @Primary
-  public CountableNotiManager countableNotiManager() {
+  public NotiManager NotiManager() {
     return new CountableNotiManager();
   }
 }

--- a/src/main/java/net/slipp/todo_list/CountableNotiManager.java
+++ b/src/main/java/net/slipp/todo_list/CountableNotiManager.java
@@ -1,0 +1,21 @@
+package net.slipp.todo_list;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Primary
+@Component
+public class CountableNotiManager extends NotiManager {
+
+  private int callCount = 0;
+
+  public int getCallCount() {
+    return this.callCount;
+  }
+
+  @Override
+  public void notify(String title) throws RuntimeException {
+    this.callCount++;
+    super.notify(title);
+  }
+}

--- a/src/test/java/net/slipp/todo_list/CountableNotiManagerTest.java
+++ b/src/test/java/net/slipp/todo_list/CountableNotiManagerTest.java
@@ -15,19 +15,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {CountableNotiManagerTest.MockBeanConfig.class, AppConfig.class})
+@ContextConfiguration(classes = {AppConfig.class})
 public class CountableNotiManagerTest {
-
-  @Configurable
-  public static class MockBeanConfig {
-
-    @Bean
-    @Primary
-    public CountableNotiManager countableNotiManager() {
-      return new CountableNotiManager();
-    }
-  }
-
   @Autowired
   private TodoManager todoManager;
   @Autowired

--- a/src/test/java/net/slipp/todo_list/CountableNotiManagerTest.java
+++ b/src/test/java/net/slipp/todo_list/CountableNotiManagerTest.java
@@ -15,7 +15,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {AppConfig.class, CountableNotiManagerTest.MockBeanConfig.class})
+@ContextConfiguration(classes = {CountableNotiManagerTest.MockBeanConfig.class, AppConfig.class})
 public class CountableNotiManagerTest {
 
   @Configurable

--- a/src/test/java/net/slipp/todo_list/CountableNotiManagerTest.java
+++ b/src/test/java/net/slipp/todo_list/CountableNotiManagerTest.java
@@ -1,0 +1,78 @@
+package net.slipp.todo_list;
+
+import static org.junit.Assert.*;
+
+import net.slipp.exception.RepositoryFailedException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {AppConfig.class, CountableNotiManagerTest.MockBeanConfig.class})
+public class CountableNotiManagerTest {
+
+  @Configurable
+  public static class MockBeanConfig {
+
+    @Bean
+    @Primary
+    public CountableNotiManager countableNotiManager() {
+      return new CountableNotiManager();
+    }
+  }
+
+  @Autowired
+  private TodoManager todoManager;
+  @Autowired
+  private CountableNotiManager countableNotiManager;
+
+  @Before
+  public void setUp() throws Exception {
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  @Test
+  public void Todo를_생성할때마다_count가_증가되는지_확인() {
+    String TITLE = "TITLE";
+    String CONTENT = "CONTENT";
+
+    Todo todo = new Todo();
+    todo.setTitle(TITLE);
+    todo.setContent(CONTENT);
+
+    int previousNotiCount = countableNotiManager.getCallCount();
+    todoManager.create(todo);
+    int afterNotiCount = countableNotiManager.getCallCount();
+
+    assertEquals(afterNotiCount, previousNotiCount + 1);
+  }
+
+  private static class MockNotiManager extends CountableNotiManager {
+
+    private static String DEFAULT_PASSED_TITLE = null;
+    private static Exception exception;
+    private static String passedTitle = DEFAULT_PASSED_TITLE;
+
+    @Override
+    public void notify(String title) throws RuntimeException {
+
+      if (exception != null && exception.getClass() == RuntimeException.class) {
+        throw (RuntimeException) exception;
+      }
+
+      passedTitle = title;
+    }
+  }
+
+
+}


### PR DESCRIPTION
- [ST-5 Noti 수가 맞는 걸 확인](https://www.slipp.net/wiki/pages/viewpage.action?pageId=30769521)
- NotiManager를 호출한 수가 실제 SMS서비스 업체가 받은 수와 다르다고 연락이 옴. 이 쪽의 오류가 없는 것을 확인하자.
- NotiManager 호출횟수 정보를 가지고 있는 CountableNotiManager(기존 NotiManager 상속) 구현
